### PR TITLE
Issue #9. Rely on artifactId rather than name.

### DIFF
--- a/core_xml_functions.sh
+++ b/core_xml_functions.sh
@@ -13,9 +13,9 @@ jirac_get_maven_version() {
 	echo $($cmd sel -N ns="http://maven.apache.org/POM/4.0.0" -t -m "/ns:project/ns:version/text()" -c . -n "$1")
 }
 
-jirac_get_maven_project_name() {
+jirac_get_maven_project_artifact_id() {
 	cmd=`xml_parser`
-	echo $($cmd sel -N ns="http://maven.apache.org/POM/4.0.0" -t -m "/ns:project/ns:name/text()" -c . -n "$1")
+	echo $($cmd sel -N ns="http://maven.apache.org/POM/4.0.0" -t -m "/ns:project/ns:artifactId/text()" -c . -n "$1")
 }
 
 jirac_get_scm_url() {

--- a/jirac
+++ b/jirac
@@ -125,7 +125,7 @@ jirac_echo ""
 
 jirac_echo "## Grabbing Maven name, artifact version and SCM URL... "
 
-project=$(jirac_get_maven_project_name "$project_pom")
+project=$(jirac_get_maven_project_artifact_id "$project_pom")
 project_version=$(jirac_get_maven_version "$project_pom")
 gitlab_base_url=$(jirac_get_scm_url "$project_pom")
 if [ -z "$gitlab_base_url" ]


### PR DESCRIPTION
Maven makes <artifactId> obviously mandatory, while <name> is
optional.
