### PR TITLE
ISSUE #9: use name if available in pom.xml, otherwise artifactId

### DIFF
--- a/core_xml_functions.sh
+++ b/core_xml_functions.sh
@@ -8,22 +8,46 @@ xml_parser() {
 	fi
 }
 
-jirac_get_maven_version() {
+##
+# $1: node selecting XPath expression ("ns" alias is predifined for Maven's POM namespace)
+# $2: path to XML file
+##
+node_text() {
+	# can not use an empty string as the default output, using this secret constant in place
+	NOT_FOUND_NODE="not found bastaaa"
 	cmd=`xml_parser`
-	echo $($cmd sel -N ns="http://maven.apache.org/POM/4.0.0" -t -m "/ns:project/ns:version/text()" -c . -n "$1")
+	value=$($cmd sel -N ns="http://maven.apache.org/POM/4.0.0" -t --if "($1)" -c "$1/text()" -n --else -o "$NOT_FOUND_NODE" "$2")
+	if [ "$value" = "$NOT_FOUND_NODE" ]; then
+		echo ""
+	else
+		echo "$value"
+	fi
 }
 
-jirac_get_maven_project_artifact_id() {
+jirac_get_maven_version() {
 	cmd=`xml_parser`
-	echo $($cmd sel -N ns="http://maven.apache.org/POM/4.0.0" -t -m "/ns:project/ns:artifactId/text()" -c . -n "$1")
+	echo $(node_text "/ns:project/ns:version" "$1")
+}
+
+##
+# project name is the value of name tag if present and non empty, otherwise the value of the artifactId tag
+##
+jirac_get_maven_project_name() {
+	cmd=`xml_parser`
+	name=$(node_text "/ns:project/ns:name" "$1")
+	if [ -z "$name" ]; then
+		echo $(node_text "/ns:project/ns:artifactId" "$1")
+	else
+		echo "$name"
+	fi
 }
 
 jirac_get_scm_url() {
 	cmd=`xml_parser`
-	echo $($cmd sel -N ns="http://maven.apache.org/POM/4.0.0" -t -m "/ns:project/ns:scm/ns:url/text()" -c . -n "$1")
+	echo $(node_text "/ns:project/ns:scm/ns:url" "$1")
 }
 
 jirac_get_connection_url() {
 	cmd=`xml_parser`
-	echo $($cmd sel -N ns="http://maven.apache.org/POM/4.0.0" -t -m "/ns:project/ns:scm/ns:connection/text()" -c . -n "$1" | cut -d':' -f3- | sed  's/\.git//')
+	echo $(node_text "/ns:project/ns:scm/ns:connection" "$1" | cut -d':' -f3- | sed 's/\.git//')
 }

--- a/jirac
+++ b/jirac
@@ -125,7 +125,7 @@ jirac_echo ""
 
 jirac_echo "## Grabbing Maven name, artifact version and SCM URL... "
 
-project=$(jirac_get_maven_project_artifact_id "$project_pom")
+project=$(jirac_get_maven_project_name "$project_pom")
 project_version=$(jirac_get_maven_version "$project_pom")
 gitlab_base_url=$(jirac_get_scm_url "$project_pom")
 if [ -z "$gitlab_base_url" ]


### PR DESCRIPTION
j'ai implémenté la fonctionnalité : on utilise le name si la balise est présente et non vide, sinon on prend le artifiactId

J'ai du modifier la récupération du texte d'un noeud (au passage, j'ai factorisé ce code) pour que l'on ai pas de warning dans stdout quand le noeud n'existe pas. Ca fonctionne avec xmlstartlet mais je ne sais pas si ça fonctionne sous MAC.

=> **a tester sous MAC avant intégration**
