### PR TITLE
issue #12: remove extra line return at beginning of generated comment

### DIFF
--- a/jirac
+++ b/jirac
@@ -194,8 +194,7 @@ jirac_echo -e "## \033[7mFINAL RESULT...\033[m"
 temp_clip=$(jirac_mktemp)
 
 #TODO: real clean template
-echo "
-*$project*
+echo "*$project*
 * branche   : $branch
 * version   : $project_version" > "$temp_clip"
 if [ "$print_mode" = "0" ]; then


### PR DESCRIPTION
contrairement au titre de l'issue #12, la suppression du saut ligne dans cette PR est valable pour les tous les print-mode
