### PR TITLE
[#33] --standard-output now effectively change log level

### DIFF
--- a/jirac
+++ b/jirac
@@ -44,7 +44,7 @@ while [ $# -gt 0 ]; do
             ;;
          --standard-output )
             output_mode="o"
-            silent_mode="yes" # implicitly enables silent mode
+            log_level=0 # implicitly change log level to ERROR
             ;;
         --print-mode | -print-mode | --p | -p )
             test -z $2 && usage_and_exit "Print mode option requires an argument!"

--- a/ui_functions.sh
+++ b/ui_functions.sh
@@ -78,5 +78,5 @@ jirac_help() {
     echo "    --standard-output: generated comment is printed to stdout instead of the clipboard"
     echo "             - useful to pipe jirac generated comment to another command"
     echo "             - requires at least one of options --number and --grep to be set"
-    echo "             - implicitly enables silence mode (option --silent)"
+    echo "             - implicitly changes log level to 0 (only error logs)"
 }


### PR DESCRIPTION
--standard-output used to implictly enable silent-mode (or actually fail at doing it) but since errors are printed to stderr, there is no need to silence them, changing log level to display only ERROR is enough
