### PR TITLE
[#35] abort if no upstream branch is set but --standard-output is set

### DIFF
--- a/jirac
+++ b/jirac
@@ -146,6 +146,9 @@ else
 fi
 
 # branch
+if [[ "$output_mode" = "o" && -z "$branch" ]]; then
+    message_and_exit "Your branch must have an upstream set in order to use option --standard-output"
+fi
 while [ -z "$branch" ]; do
     jirac_log INFO "Your branch has no upstream set, please choose another one:"
     jirac_select Branch "git branch -r" $project_git_location


### PR DESCRIPTION
PR pas très complexe, mais deux points à adresser quand même:
- le message vous convient-il ?
- il va falloir songer à refactor le fichier jirac en méthode, ça devient très très long...
