### PR TITLE
[#44] fix dependency check broken for xml parser

### DIFF
--- a/jirac
+++ b/jirac
@@ -84,7 +84,7 @@ else
     jirac_check_dependency tac
 fi
 
-for dependency in git sed xml_parser; do
+for dependency in git sed `xml_parser`; do
     jirac_check_dependency $dependency
 done
 


### PR DESCRIPTION
la correction se fait en deux `'`, c'est peu, mais ça change tout :)
